### PR TITLE
ci: publish xlsx.ttl to gh pages

### DIFF
--- a/.github/workflows/generate-chart.yml
+++ b/.github/workflows/generate-chart.yml
@@ -33,6 +33,9 @@ jobs:
           run: |
             pwd
             poetry run python ./chartgen.py
+        
+        - name: Publish xlsx.ttl
+          run: cp ../source/xlsx.ttl ./chart-generate/out/xlsx.ttl
   
         - name: Deploy 🚀
           uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
This PR publishes the SKOS-XL labels to GitHub Pages.