### PR TITLE
fix: xlsx.ttl skosxl namespace

### DIFF
--- a/source/xlsx.ttl
+++ b/source/xlsx.ttl
@@ -1,4 +1,4 @@
-@prefix ns1: <ttp://www.w3.org/2008/05/skos-xl#> .
+@prefix ns1: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix schema: <https://schema.org/> .
 
 <http://resource.geosciml.org/classifier/ics/ischart> ns1:prefLabel [ a ns1:Label ;


### PR DESCRIPTION
The skosxl namespace is missing the `h` in `http`.