### PR TITLE
ci: new releases both deploy the interactive chart and build PDF files based on the data in the release

### DIFF
--- a/.github/workflows/Publish-Release.yml
+++ b/.github/workflows/Publish-Release.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - "v*.*.*"
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/deploy-chart.yml
+++ b/.github/workflows/deploy-chart.yml
@@ -31,3 +31,8 @@ jobs:
           clean-exclude: |
             chart.json
             chart.*.json
+  
+  publish-pdfs:
+    # This job depends on the chart RDF data that is published in the deploy job.
+    needs: deploy
+    uses: ./.github/workflows/Publish-Release.yml


### PR DESCRIPTION
Previously, there was a race condition where the publish-release workflow runs at the same time as the deploy-chart workflow. Because the deploy-chart workflow publishes the latest data to GH pages, it's possible for the publish-release workflow, which builds the PDF files, to use stale data.