### PR TITLE
feat: update PDF download select to use new file format

### DIFF
--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -49,7 +49,7 @@ jobs:
           echo $date 
           echo $version
           #get official version first
-          ${{ steps.setup-chrome.outputs.chrome-path }} --user-data-dir=./chrome-temp-profile --headless --no-sandbox --disable-gpu --print-to-pdf=chart-ICS_Chart_${{ steps.chart-version.outputs.version }}.pdf --no-pdf-header-footer --virtual-time-budget=5000 "https://stratigraphy.org/chart-data/?scale=print"
+          ${{ steps.setup-chrome.outputs.chrome-path }} --user-data-dir=./chrome-temp-profile --headless --no-sandbox --disable-gpu --print-to-pdf=ICS_Chart_${{ steps.chart-version.outputs.version }}.pdf --no-pdf-header-footer --virtual-time-budget=5000 "https://stratigraphy.org/chart-data/?scale=print"
           for i in $langs
           do
             echo $i 

--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -53,7 +53,7 @@ jobs:
           for i in $langs
           do
             echo $i 
-            output="ICS_Chart_${{ steps.chart-version.outputs.version }}-$i.pdf"
+            output="ICS_Chart_${{ steps.chart-version.outputs.version }}_$i.pdf"
             echo "creating $output"
             #generate each language version
             echo "https://stratigraphy.org/chart-data/?scale=print&language=$i"

--- a/chart-ui/components/DynamicChart.vue
+++ b/chart-ui/components/DynamicChart.vue
@@ -133,7 +133,7 @@ function getSKOSXLLabelsData() {
     });
 }
 const pdfVersion = ref("");
-const downloadVersion = ref("official");
+const downloadVersion = ref("");
 onMounted(async () => {
   const timeout = setTimeout(() => {
     error.value = { message: "Timed out fetching chart data" };
@@ -215,11 +215,14 @@ const handleView = (node) => {
   target.value = node;
   infoTarget.value = dataLookup.value[target.value];
 };
-const downlaodLink = computed(() => {
-  return `https://github.com/i-c-stratigraphy/chart-data/releases/download/v${pdfVersion.value}/chart-${downloadVersion.value}.pdf`;
+const versionInfo = computed(() => {
+  return meta.value.versionInfo;
+});
+const downloadLink = computed(() => {
+  return `https://github.com/i-c-stratigraphy/chart-data/releases/download/v${pdfVersion.value}/ICS_Chart_${versionInfo.value}${downloadVersion.value ? `_${downloadVersion.value}` : ""}.pdf`;
 });
 const downloadPdf = (e) => {
-  const link = downlaodLink.value;
+  const link = downloadLink.value;
   const a = document.createElement("a");
   a.href = link;
   a.download = link.split("/").pop();
@@ -331,7 +334,7 @@ const commissionTitle = computed(() => {
           <label v-if="pdfVersion != ''">
             Download:
             <select v-model="downloadVersion">
-              <option value="official">Main</option>
+              <option value="">Main</option>
               <option v-for="lang in langs" :key="lang" :value="lang">
                 {{ languageNames.of(lang) }} ({{
                   new Intl.DisplayNames([lang], { type: "language" }).of(lang)


### PR DESCRIPTION
Interactive chart now uses the new PDF file structure defined in https://github.com/i-c-stratigraphy/chart-data/issues/72.